### PR TITLE
Adding SkyPilot example for FlexGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_
 Note that only a subset of HELM scenarios is tested. See more tested scenarios [here](flexgen/apps/helm_passed_30b.sh).
 
 ### Run FlexGen on any cloud with SkyPilot
-FlexGen benchmark can be launched with [SkyPilot](http://skypilot.co), a tool for launching ML jobs on any cloud.
+FlexGen benchmark can be launched with [SkyPilot](https://github.com/skypilot-org/skypilot), a tool for launching ML jobs on any cloud.
 You can use a single command below to automatically launch the benchmark on any cloud with SkyPilot, after you setup your cloud account locally (check how to setup SkyPilot [here](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)).
 ```
 sky launch -c flexgen --detach-setup flexgen/apps/task.yaml

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ First, install SkyPilot and check you have some cloud credentials ([docs](https:
 pip install "skypilot[aws,gcp,azure,lambda]"  # pick your clouds
 sky check
 ```
-You can now use a single command to automatically launch the benchmark on any cloud:
+You can now use a single command to launch the benchmark on any cloud, which automatically finds a region (in the cheapest-price order) with availability for the requested GPUs:
 ```bash
 sky launch -c flexgen --detach-setup flexgen/apps/skypilot.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -66,13 +66,20 @@ python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_
 ```
 Note that only a subset of HELM scenarios is tested. See more tested scenarios [here](flexgen/apps/helm_passed_30b.sh).
 
-### Run FlexGen on any cloud with SkyPilot
-FlexGen benchmark can be launched with [SkyPilot](http://skypilot.co), a tool for launching ML jobs on any cloud.
-You can use a single command below to automatically launch the benchmark on any cloud with SkyPilot, after you setup your cloud account locally (check how to setup SkyPilot [here](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)).
+### Run FlexGen on Any Cloud with SkyPilot
+FlexGen benchmark can be launched with [SkyPilot](https://github.com/skypilot-org/skypilot), a tool for launching ML jobs on any cloud.
+First, install SkyPilot and check you have some cloud credentials ([docs](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)):
+```bash
+pip install "skypilot[aws,gcp,azure,lambda]"  # pick your clouds
+sky check
 ```
-sky launch -c flexgen --detach-setup flexgen/apps/task.yaml
+You can now use a single command to automatically launch the benchmark on any cloud:
+```bash
+sky launch -c flexgen --detach-setup flexgen/apps/skypilot.yaml
 ```
-Note that you can replace the run section with any FlexGen command. You can log into the cluster running the job with `ssh flexgen` and terminate the cluster with `sky down flexgen`.
+You can then log into the cluster running the job with `ssh flexgen` for monitoring. Once the job has finished, you can terminate the cluster with `sky down flexgen` or pass in `--down` flag to the command above to have the cluster terminate itself automatically.
+
+To run any other FlexGen command, you can edit [`flexgen/apps/skypilot.yaml`](./flexgen/apps/skypilot.yaml) and replace the `run` section.
 
 ### Data Wrangling
 You can run the examples in this paper, ['Can Foundation Models Wrangle Your Data?'](https://arxiv.org/abs/2205.09911), by following the instructions [here](flexgen/apps/data_wrangle).

--- a/README.md
+++ b/README.md
@@ -66,8 +66,18 @@ python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_
 ```
 Note that only a subset of HELM scenarios is tested. See more tested scenarios [here](flexgen/apps/helm_passed_30b.sh).
 
+### Run FlexGen on any cloud with SkyPilot
+FlexGen benchmark can be launched with [SkyPilot](http://skypilot.co), a tool for launching ML jobs on any cloud.
+You can use a single command below to automatically launch the benchmark on any cloud with SkyPilot, after you setup your cloud account locally (check how to setup SkyPilot [here](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)).
+```
+sky launch -c flexgen flexgen/apps/task.yaml
+```
+Note that you can replace the run section with any FlexGen command. You can log into the cluster running the job with `ssh flexgen` and terminate the cluster with `sky down flexgen`.
+
 ### Data Wrangling
 You can run the examples in this paper, ['Can Foundation Models Wrangle Your Data?'](https://arxiv.org/abs/2205.09911), by following the instructions [here](flexgen/apps/data_wrangle).
+
+
 
 ## Performance Benchmark
 ### Generation Throughput (token/s)
@@ -85,6 +95,7 @@ The corresponding effective batch sizes are in parentheses. Please see [here](be
 - Metric: generation throughput (token/s) = number of the generated tokens / (time for processing prompts + time for generation).  
 
 How to [reproduce](benchmark/flexgen).
+
 
 ## Roadmap
 We plan to work on the following features.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Note that only a subset of HELM scenarios is tested. See more tested scenarios [
 FlexGen benchmark can be launched with [SkyPilot](http://skypilot.co), a tool for launching ML jobs on any cloud.
 You can use a single command below to automatically launch the benchmark on any cloud with SkyPilot, after you setup your cloud account locally (check how to setup SkyPilot [here](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)).
 ```
-sky launch -c flexgen flexgen/apps/task.yaml
+sky launch -c flexgen --detach-setup flexgen/apps/task.yaml
 ```
 Note that you can replace the run section with any FlexGen command. You can log into the cluster running the job with `ssh flexgen` and terminate the cluster with `sky down flexgen`.
 

--- a/flexgen/apps/README.md
+++ b/flexgen/apps/README.md
@@ -12,3 +12,9 @@ Run Massive Multitask Language Understanding (MMLU) scenario.
 ```
 python3 helm_run.py --description mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical --pad-to-seq-len 512 --model facebook/opt-30b --percent 20 80 0 100 0 100 --gpu-batch-size 48 --num-gpu-batches 3 --max-eval-instance 100
 ```
+
+### Run on any cloud with SkyPilot
+Run FlexGen benchmark on any cloud with [SkyPilot](http://skypilot.co).
+```
+sky launch -c flexgen task.yaml
+```

--- a/flexgen/apps/README.md
+++ b/flexgen/apps/README.md
@@ -14,7 +14,16 @@ python3 helm_run.py --description mmlu:model=text,subject=abstract_algebra,data_
 ```
 
 ### Run on any cloud with SkyPilot
-Run FlexGen benchmark on any cloud with [SkyPilot](http://skypilot.co).
+FlexGen benchmark can be launched with [SkyPilot](https://github.com/skypilot-org/skypilot), a tool for launching ML jobs on any cloud.
+First, install SkyPilot and check you have some cloud credentials ([docs](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)):
+```bash
+pip install "skypilot[aws,gcp,azure,lambda]"  # pick your clouds
+sky check
 ```
-sky launch -c flexgen --detach-setup task.yaml
+You can now use a single command to automatically launch the benchmark on any cloud:
+```bash
+sky launch -c flexgen --detach-setup skypilot.yaml
 ```
+You can then log into the cluster running the job with `ssh flexgen` for monitoring. Once the job has finished, you can terminate the cluster with `sky down flexgen` or pass in `--down` flag to the command above to have the cluster terminate itself automatically.
+
+To run any other FlexGen command, you can edit [`skypilot.yaml`](skypilot.yaml) and replace the `run` section.

--- a/flexgen/apps/README.md
+++ b/flexgen/apps/README.md
@@ -33,7 +33,7 @@ First, install SkyPilot and check you have some cloud credentials ([docs](https:
 pip install "skypilot[aws,gcp,azure,lambda]"  # pick your clouds
 sky check
 ```
-You can now use a single command to automatically launch the benchmark on any cloud:
+You can now use a single command to launch the benchmark on any cloud, which automatically finds a region (in the cheapest-price order) with availability for the requested GPUs:
 ```bash
 sky launch -c flexgen --detach-setup skypilot.yaml
 ```

--- a/flexgen/apps/README.md
+++ b/flexgen/apps/README.md
@@ -16,5 +16,5 @@ python3 helm_run.py --description mmlu:model=text,subject=abstract_algebra,data_
 ### Run on any cloud with SkyPilot
 Run FlexGen benchmark on any cloud with [SkyPilot](http://skypilot.co).
 ```
-sky launch -c flexgen task.yaml
+sky launch -c flexgen --detach-setup task.yaml
 ```

--- a/flexgen/apps/skypilot.yaml
+++ b/flexgen/apps/skypilot.yaml
@@ -1,9 +1,11 @@
-# benchmark.yaml
 # A SkyPilot job definition for benchmarking FlexGen.
+# References:
+#   https://skypilot.readthedocs.io/en/latest/getting-started/quickstart.html
+#   https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html
 
 # Specify the resources required for this job.
 resources:
-  accelerators: T4:1
+  accelerators: T4:1  # Can replace with other GPU type and count, see `sky show-gpus`.
   instance_type: n1-highmem-32 # On GCP with 1 T4 GPU and more than 200GB of RAM.
   # instance_type: g4dn.16xlarge # On AWS with 1 T4 GPU and more than 200GB of RAM.
   # Azure does not support T4 GPUs with more than 200GB of RAM.

--- a/flexgen/apps/task.yaml
+++ b/flexgen/apps/task.yaml
@@ -11,6 +11,7 @@ setup: |
   echo Installing CUDA 11.6.0
   sudo sh cuda_11.6.0_510.39.01_linux.run --silent --toolkit
   
+  # Create conda environment
   conda create -y -n flexgen python=3.9
   conda activate flexgen
   pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu116
@@ -22,6 +23,7 @@ setup: |
   pip install -e .
 
 run: |
+  # Run any FlexGen command
   conda activate flexgen
   # python3 -m flexgen.flex_opt --model facebook/opt-1.3b
   python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical --pad-to-seq-len 512 --model facebook/opt-30b --percent 20 80 0 100 0 100 --gpu-batch-size 48 --num-gpu-batches 3 --max-eval-instance 100

--- a/flexgen/apps/task.yaml
+++ b/flexgen/apps/task.yaml
@@ -1,9 +1,12 @@
 # benchmark.yaml
 # A SkyPilot job definition for benchmarking FlexGen.
 
+# Specify the resources required for this job.
 resources:
   accelerators: T4:1
-  instance_type: n1-highmem-32
+  instance_type: n1-highmem-32 # On GCP with 1 T4 GPU and more than 200GB of RAM.
+  # instance_type: g4dn.16xlarge # On AWS with 1 T4 GPU and more than 200GB of RAM.
+  # Azure does not support T4 GPUs with more than 200GB of RAM.
 
 setup: |
   # Install Latest CUDA
@@ -26,4 +29,7 @@ run: |
   # Run any FlexGen command
   conda activate flexgen
   # python3 -m flexgen.flex_opt --model facebook/opt-1.3b
-  python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical --pad-to-seq-len 512 --model facebook/opt-30b --percent 20 80 0 100 0 100 --gpu-batch-size 48 --num-gpu-batches 3 --max-eval-instance 100
+  python3 -m flexgen.apps.helm_run \
+          --description mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical \
+          --pad-to-seq-len 512 --model facebook/opt-30b --percent 20 80 0 100 0 100 \
+          --gpu-batch-size 48 --num-gpu-batches 3 --max-eval-instance 100

--- a/flexgen/apps/task.yaml
+++ b/flexgen/apps/task.yaml
@@ -1,0 +1,27 @@
+# benchmark.yaml
+# A SkyPilot job definition for benchmarking FlexGen.
+
+resources:
+  accelerators: T4:1
+  instance_type: n1-highmem-32
+
+setup: |
+  # Install Latest CUDA
+  wget -q https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux.run
+  echo Installing CUDA 11.6.0
+  sudo sh cuda_11.6.0_510.39.01_linux.run --silent --toolkit
+  
+  conda create -y -n flexgen python=3.9
+  conda activate flexgen
+  pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu116
+  pip install crfm-helm==0.2.1
+
+  # Install flexgen
+  git clone https://github.com/FMInference/FlexGen.git || true
+  cd FlexGen
+  pip install -e .
+
+run: |
+  conda activate flexgen
+  # python3 -m flexgen.flex_opt --model facebook/opt-1.3b
+  python3 -m flexgen.apps.helm_run --description mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical --pad-to-seq-len 512 --model facebook/opt-30b --percent 20 80 0 100 0 100 --gpu-batch-size 48 --num-gpu-batches 3 --max-eval-instance 100


### PR DESCRIPTION
This PR is to add the SkyPilot example for the FlexGen benchmark. It will make the benchmark more reproducible and convenient to manage.

Several future TODOs for SkyPilot:
1. Use the `memory` filtering in the `resources` section (https://github.com/skypilot-org/skypilot/pull/1746) to make the example easier to run on different clouds, i.e.
```
resources:
  cpus: 32+
  memory_gb: 200+
  accelerators: T4
```
2. Add the support in changing the disk type to be used for the instance, so that we can run the commands that requires high performance SSD disks.

Tested:
- [x] `sky launch -c flexgen --use-spot --detach-setup ./flexgen/apps/task.yaml`